### PR TITLE
Implements remote depending parties defaults

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -54,7 +54,8 @@
 					"type": "array",
           "Q:default": {
             "type": "value-depending",
-            "key": "data/parliament"
+            "key": "parliament:data/parliament",
+            "path": "data/parties?parliament={parliament}"
           },
 					"items": {
 						"type": "object",


### PR DESCRIPTION
This is WIP at the moment and just adds one possible way of implementing this to the schema.

Q-election-votes would need to implement the endpoints `/data/parliaments` and `data/parties?parliament={parliament}` to provide the `enum` for the parliament select and to parties to fill the defaults for `parties`.

Q-editor would then handle this, listen for a change at `data.parliament` of the item and then asking the configured endpoint for defaults. It should probably have a confirm dialog to make sure this does no happen accidentialy as it would override whats there (which makes me think that `Q:defaults` is not a good name)

happy to hear your thoughts @fuenkchen.