### PR TITLE
Release 2.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-election-votes",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3265,9 +3265,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nzz/q-election-votes",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Q Election Votes",
   "keywords": [
     "storytelling",

--- a/resources/fixtures/data/results-threshold-color-codes-uncertainty.json
+++ b/resources/fixtures/data/results-threshold-color-codes-uncertainty.json
@@ -21,9 +21,7 @@
         "colorCode": "#1b53be"
       },
       "errorMargin": {
-        "lower": 3,
-        "bestGuess": 5,
-        "upper": 7
+        "bestGuess": 5
       },
       "name": "Partei B"
     },
@@ -32,9 +30,7 @@
         "colorCode": "#009ec3"
       },
       "errorMargin": {
-        "lower": 80,
-        "bestGuess": 82,
-        "upper": 87
+        "bestGuess": 82
       },
       "name": "Tollak Party "
     },

--- a/views/HtmlStatic.html
+++ b/views/HtmlStatic.html
@@ -103,6 +103,9 @@
         let maxErrorMarginValue = undefined;;
         // if there are already any errorMargins the first party 
         // of sorted list of party has max errorMargin upper bound
+        if (sortedParties[0] && sortedParties[0].errorMargin && sortedParties[0].errorMargin.bestGuess) {
+          maxErrorMarginValue = sortedParties[0].errorMargin.bestGuess;
+        }
         if (sortedParties[0] && sortedParties[0].errorMargin && sortedParties[0].errorMargin.upper) {
           maxErrorMarginValue = sortedParties[0].errorMargin.upper;
         }


### PR DESCRIPTION
- fixes the calculation of maxErrorMarginValue (needed for various width/position calculation for the bar per party) for the case where errorMargin contains only bestGuess and no upper bound.