### PR TITLE
use s-font-note for party name and reduce bar height to 16px [WIP]

### DIFF
--- a/styles_src/default.scss
+++ b/styles_src/default.scss
@@ -94,11 +94,11 @@ $error-marginBarHeight: 3px;
 }
 
 .q-election-item-dot-color {
-  width: 7px;
-  height: 7px;
+  width: 4px;
+  height: 4px;
   border-radius: 50%;
   position: absolute;
-  top: ($barHeight - 7px) / 2;
+  top: ($barHeight - 4px) / 2;
   background-color: currentColor;
   transform: translateX(-50%);
 }
@@ -110,9 +110,9 @@ $error-marginBarHeight: 3px;
 }
 
 .q-election-item-bar-color--slim {
-  height: 3px;
+  height: 2px;
   position: absolute;
-  top: ($barHeight - 3px) / 2;
+  top: ($barHeight - 2px) / 2;
 }
 
 .q-election-item-bar-color--fullwidth {

--- a/styles_src/default.scss
+++ b/styles_src/default.scss
@@ -1,4 +1,4 @@
-$barHeight: 25px;
+$barHeight: 16px;
 $error-marginBarHeight: 3px;
 
 .q-election {

--- a/views/ElectionItem.svelte
+++ b/views/ElectionItem.svelte
@@ -5,7 +5,7 @@
 
 <div class="q-election-item">
   <div class="q-election-item-text">
-    <div class="s-font-text-s q-election-item-text-party">{item.name}</div>
+    <div class="s-font-note q-election-item-text-party">{item.name}</div>
     {#if item.percentage}
       <div class="s-font-note q-election-item-text-current">
          {item.percentage}%


### PR DESCRIPTION
- changed according to designers wishes
- to be released on prod before october 20th.

Please do this before merging @philipkueng 
- [ ] adjust the sizes in ElectionItemErrorMargin component to still look correct (maybe see https://github.com/nzzdev/Q-custom-code-projects/pull/156 for inspiration). ideally all the values would be derived from the bar-height variable, so this can easily be changed in the future.